### PR TITLE
Make repository discoverable from PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ data = dict(
         license='BSD License',
         description='Pure python package for reading/writing dBase, FoxPro, and Visual FoxPro .dbf files (including memos)',
         long_description=long_desc,
-        url='https://pypi.python.org/pypi/dbf',
+        url='https://github.com/ethanfurman/dbf',
         packages=['dbf', ],
         package_data={
            'dbf' : [


### PR DESCRIPTION
Thank you for developing this package.

It was not totally obvious that this repos belongs to the PyPI page.
Having this link will make it easier for the next people trying to find the repos of the package.