### PR TITLE
Added Error Handling for Records not starting with SPACE or Asterisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Python DBF Reader
+
+Forked from user [Ethanfurman](https://github.com/ethanfurman/dbf), with a small patch to increase usability of the program. The patch applies to error handling of certain fields not starting
+with the expected character. Instead of throwing the error and stopping, it now throws the error, logs it and continues on with operation. 
+
+This patch allowed me to read in files and get the needed information that I could not before, due to the breaking error handling. 

--- a/dbf/__init__.py
+++ b/dbf/__init__.py
@@ -3096,8 +3096,14 @@ class Record(object):
         if record._data[0] == NULL:
             record._data[0] = SPACE
         if record._data[0] not in (SPACE, ASTERISK):
-            # TODO: log warning instead
-            raise DbfError("record data not correct -- first character should be a ' ' or a '*'.")
+            # Create error log to write erroneous records to
+            with open('error.log', 'a') as f:
+                now = datetime.datetime.now()
+                f.write('\n')
+                f.write(now.strftime("%Y-%m-%d %H:%M:%S"))
+                f.write("\tError with record: " + str(record[0]))
+                f.write("\t Expected character SPACE or ASTERISK, instead found: " + str(record._data[0]))
+            pass
         if not _fromdisk and layout.location == ON_DISK:
             record._update_disk()
         return record


### PR DESCRIPTION
Added a small change to error handling of files that do not start with a SPACE or ASTERISK. Instead of raising a DBFError and terminating the program, it instead marks it as an erroneous record in the newly created error.log file and continues.

Errors are marked with current date and time, the record in question (identified by the record[0] field) and the record._data[0] that is causing the error.